### PR TITLE
Added special case for read long type value from cursor

### DIFF
--- a/freezer-compiler/src/main/java/fr/xebia/android/freezer/ProcessUtils.java
+++ b/freezer-compiler/src/main/java/fr/xebia/android/freezer/ProcessUtils.java
@@ -52,8 +52,10 @@ public class ProcessUtils {
 
     public static String getFieldType(VariableElement variableElement) {
         TypeName typeName = TypeName.get(variableElement.asType());
-        if (typeName == TypeName.INT || typeName == TypeName.BOOLEAN || typeName == TypeName.LONG || typeName == TypeName.BYTE)
+        if (typeName == TypeName.INT || typeName == TypeName.BOOLEAN || typeName == TypeName.BYTE)
             return "Int";
+        else if (typeName == TypeName.LONG)
+            return "Long";
         else if (typeName == TypeName.FLOAT)
             return "Float";
         else if (ClassName.get(String.class).equals(typeName))


### PR DESCRIPTION
After test your incredibly good library, and I noticed a strange behavior.

For my case I have next model 


```
@Model
public class AppStatsItem {
    String eventHash;
    long startTime;
    long endTime;
    String appId;
} 
```
and after in generated 

`public final class AppStatsItemCursorHelper`

I'm search next code:

```
public static AppStatsItem fromCursor(Cursor cursor, SQLiteDatabase db, int start) {
  AppStatsItem object = new AppStatsItemEntity();
  ((fr.xebia.android.freezer.DataBaseModel)object).setDatabaseModelId(cursor.getLong(start));
  object.eventHash = cursor.getString(start+1);
  object.startTime = cursor.getInt(start+2);
  object.endTime = cursor.getInt(start+3);
  object.appId = cursor.getString(start+4);

  return object;
}
```

for me it means that the result is selected from the database will be cut on the int
